### PR TITLE
Fix dataset arg bug and expose experiment helpers

### DIFF
--- a/feedflipnets/train.py
+++ b/feedflipnets/train.py
@@ -11,7 +11,11 @@ from .models import forward_pass, backprop_deltas
 
 
 def train_single(method: str, depth: int, freq: int, seed: int, epochs: int = 500) -> Tuple[List[float], float, int]:
-    X, Y = make_dataset(freq, seed)
+    # second argument of ``make_dataset`` is the number of points; the previous
+    # implementation mistakenly passed ``seed`` here which resulted in empty
+    # datasets when ``seed`` was 0.  Explicitly bind the keyword to avoid such
+    # mixups.
+    X, Y = make_dataset(freq, seed=seed)
     N = X.shape[1]
     np.random.seed(seed)
 

--- a/ternary_dfa_experiment.py
+++ b/ternary_dfa_experiment.py
@@ -1,9 +1,20 @@
-"""Wrapper for backward compatibility.
+"""Compatibility wrapper for the experiment entry point.
 
-This script forwards execution to :mod:`experiments.ternary_dfa_experiment`.
+Historically :mod:`ternary_dfa_experiment` exposed helper functions such as
+``make_dataset`` and ``sweep_and_log``.  The implementation now lives under
+``experiments/ternary_dfa_experiment.py`` but tests (and user code) may still
+import these utilities from this top level module.  To keep backwards
+compatibility we re-export the relevant functions and ``main``.
 """
 
-from experiments.ternary_dfa_experiment import main
+from experiments.ternary_dfa_experiment import (
+    main,
+    parse_args,
+    sweep_and_log,
+)
+from feedflipnets.utils import make_dataset
+
+__all__ = ["main", "parse_args", "sweep_and_log", "make_dataset"]
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- fix `train_single` passing seed in place of dataset length
- re-export experiment utilities from `ternary_dfa_experiment.py`
- clean run of example after fix

## Testing
- `pytest -q`
- `python experiments/ternary_dfa_experiment.py --depths 1 2 --freqs 1 3 --epochs 5 --outdir /tmp/example`

------
https://chatgpt.com/codex/tasks/task_e_68710c761f348328a0c7459ecd59160d