### PR TITLE
Add dataset truncation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ python ternary_dfa_experiment.py --dataset mnist --depths 1 --freqs 1 \
     --epochs 1 --outdir results/mnist-mini --methods Backprop "Vanilla DFA" Momentum
 ```
 
+For a very quick smoke test you can further limit the dataset size with
+`--max-points <n>` which truncates the loaded sequence to ``n`` points.
+
 The final mean squared error after one epoch is approximately:
 
 | method       |  MSE |

--- a/experiments/ternary_dfa_experiment.py
+++ b/experiments/ternary_dfa_experiment.py
@@ -42,6 +42,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument('--seeds', type=int, nargs='+', default=[0])
     p.add_argument('--dataset', type=str, default=None,
                    help='Dataset to use (mnist, tinystories or ucr:<name>)')
+    p.add_argument('--max-points', type=int, default=None,
+                   help='Limit dataset to this many points for quick runs')
     return p.parse_args()
 
 
@@ -56,6 +58,7 @@ def main(args: argparse.Namespace | None = None) -> None:
         args.epochs,
         args.outdir,
         dataset=args.dataset,
+        max_points=args.max_points,
     )
 
 

--- a/feedflipnets/train.py
+++ b/feedflipnets/train.py
@@ -24,6 +24,7 @@ def train_single(
     seed: int,
     epochs: int = 500,
     dataset: str | None = None,
+    max_points: int | None = None,
 ) -> Tuple[List[float], float, int]:
     """Train a single network instance and return metrics."""
 
@@ -31,7 +32,7 @@ def train_single(
     # implementation mistakenly passed ``seed`` here which resulted in empty
     # datasets when ``seed`` was 0.  Explicitly bind the keyword to avoid such
     # mixups.
-    X, Y = make_dataset(freq, seed=seed, dataset=dataset)
+    X, Y = make_dataset(freq, seed=seed, dataset=dataset, max_points=max_points)
     N = X.shape[1]
     np.random.seed(seed)
 
@@ -149,6 +150,7 @@ def sweep_and_log(
     epochs: int,
     outdir: str,
     dataset: str | None = None,
+    max_points: int | None = None,
 ) -> Dict[str, np.ndarray]:
     ensure_dir(outdir)
     plots_dir = os.path.join(outdir, 'plots')
@@ -162,6 +164,7 @@ def sweep_and_log(
         'seeds': list(seeds),
         'epochs': epochs,
         'dataset': dataset or 'synthetic',
+        'max_points': max_points,
     }
     with open(os.path.join(outdir, 'summary.json'), 'w') as f:
         json.dump(meta, f, indent=2)
@@ -178,7 +181,15 @@ def sweep_and_log(
             for k in freqs:
                 curves = []
                 for s in seeds:
-                    curve, _, _ = train_single(m, d, k, s, epochs, dataset)
+                    curve, _, _ = train_single(
+                        m,
+                        d,
+                        k,
+                        s,
+                        epochs,
+                        dataset,
+                        max_points,
+                    )
                     curves.append(curve)
                     np.save(os.path.join(outdir, f"curve_{m.replace(' ','_')}_d{d}_k{k}_seed{s}.npy"), np.array(curve))
                 mean_curve = np.mean(curves, axis=0)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -15,6 +15,11 @@ def test_make_dataset_explicit_dataset():
     assert X.shape == (1, 5)
     assert Y.shape == (1, 5)
 
+def test_make_dataset_limit():
+    X, Y = make_dataset(freq=1, n=10, seed=0, dataset="synthetic", max_points=3)
+    assert X.shape == (1, 3)
+    assert Y.shape == (1, 3)
+
 def test_make_dataset_mnist_shape():
     try:
         X, Y = make_dataset(freq=1, dataset="mnist")


### PR DESCRIPTION
## Summary
- add `max_points` argument to `make_dataset`
- propagate limit through training pipeline and CLI
- document quick run option in README
- test dataset limiting for synthetic data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cd97cd34832891fd6fbb4f14f4fe