### PR TITLE
Fix sweep seed iteration when generator

### DIFF
--- a/feedflipnets/train.py
+++ b/feedflipnets/train.py
@@ -156,12 +156,14 @@ def sweep_and_log(
     plots_dir = os.path.join(outdir, 'plots')
     ensure_dir(plots_dir)
 
+    seeds = list(seeds)
+
     meta = {
         'timestamp': datetime.datetime.now().isoformat(),
         'methods': methods,
         'depths': depths,
         'freqs': freqs,
-        'seeds': list(seeds),
+        'seeds': seeds,
         'epochs': epochs,
         'dataset': dataset or 'synthetic',
         'max_points': max_points,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,4 +1,4 @@
-import os, sys, pathlib
+import os, sys, pathlib, json
 import pytest
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
@@ -36,3 +36,16 @@ def test_sweep_returns_tables(tmp_path):
     assert isinstance(tables, dict)
     assert 'Backprop' in tables
     assert tables['Backprop'].shape == (1, 1)
+
+
+def test_sweep_generator_seeds(tmp_path):
+    gen = (i for i in range(2))
+    tables = sweep_and_log([
+        'Backprop'], [1], [1], gen, epochs=1, outdir=str(tmp_path), dataset="synthetic"
+    )
+    assert isinstance(tables, dict)
+    assert os.path.exists(os.path.join(tmp_path, 'curve_Backprop_d1_k1_seed0.npy'))
+    assert os.path.exists(os.path.join(tmp_path, 'curve_Backprop_d1_k1_seed1.npy'))
+    with open(os.path.join(tmp_path, 'summary.json')) as f:
+        meta = json.load(f)
+    assert meta['seeds'] == [0, 1]


### PR DESCRIPTION
## Summary
- ensure sweep_and_log converts seeds to list upfront
- test for generator-based seeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d2f8838883288c7c7a2b0ba1d7d3