### PR TITLE
Add downloadable dataset smoke test

### DIFF
--- a/feedflipnets/utils.py
+++ b/feedflipnets/utils.py
@@ -47,6 +47,9 @@ def make_dataset(
         x = X_train[0].reshape(1, -1)
         if max_points is not None:
             x = x[:, :max_points]
+            y = y_train[0:1].astype(float).reshape(1, 1)
+            y = np.repeat(y, x.shape[1], axis=1)
+            return x, y
         return x, y_train[0:1].astype(float).reshape(1, -1)
 
     if dataset.startswith("ucr:"):
@@ -58,6 +61,9 @@ def make_dataset(
         x = X_train[0].reshape(1, -1)
         if max_points is not None:
             x = x[:, :max_points]
+            y = y_train[0:1].astype(float).reshape(1, 1)
+            y = np.repeat(y, x.shape[1], axis=1)
+            return x, y
         return x, y_train[0:1].astype(float).reshape(1, -1)
 
     if dataset == "tinystories":

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -29,6 +29,16 @@ def test_make_dataset_mnist_shape():
     assert Y.shape == (1, 1)
 
 
+@pytest.mark.parametrize("ds", ["mnist", "tinystories", "ucr:GunPoint"])
+def test_make_dataset_downloadables(ds):
+    try:
+        X, Y = make_dataset(freq=1, dataset=ds, max_points=3)
+    except Exception:
+        pytest.skip(f"{ds} dataset not available")
+    assert X.shape == (1, 3)
+    assert Y.shape == (1, 3)
+
+
 def test_sweep_returns_tables(tmp_path):
     tables = sweep_and_log(
         ['Backprop'], [1], [1], range(1), epochs=2, outdir=str(tmp_path), dataset="synthetic"


### PR DESCRIPTION
## Summary
- expand dataset utility to duplicate scalar labels when slicing
- add parameterized smoke tests for downloadable datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d2fd080c8328a66bf3118a25a18b