### PR TITLE
Add train_single method coverage

### DIFF
--- a/feedflipnets/train.py
+++ b/feedflipnets/train.py
@@ -115,6 +115,8 @@ def train_single(
             Ws[-1] = quantize_stoch(W_new, alpha * np.mean(np.abs(W_new)))
 
         delta_dfa = err
+        if block_ortho and delta_dfa.shape[0] == 1:
+            delta_dfa = np.repeat(delta_dfa, hidden_dim, axis=0)
         for l in reversed(range(depth)):
             pseudo = B[l] @ delta_dfa
             W_for_grad = shadow_Ws[l] if use_shadow else Ws[l]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -3,6 +3,7 @@ import pytest
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
 from ternary_dfa_experiment import make_dataset, sweep_and_log
+from feedflipnets.train import train_single
 
 
 def test_make_dataset_shape():
@@ -36,3 +37,31 @@ def test_sweep_returns_tables(tmp_path):
     assert isinstance(tables, dict)
     assert 'Backprop' in tables
     assert tables['Backprop'].shape == (1, 1)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "Backprop",
+        "Vanilla DFA",
+        "Structured DFA",
+        "Ternary static \u0394",
+        "Ternary + adaptive + ortho B",
+        "Ternary + adaptive + ortho B + cal",
+        "+Shadow",
+        "+Momentum",
+        "Ternary DFA on Transformer/LLM",
+    ],
+)
+def test_train_single_all_modes(method):
+    curve, _, _ = train_single(
+        method,
+        depth=1,
+        freq=1,
+        seed=0,
+        epochs=1,
+        dataset="synthetic",
+        max_points=5,
+    )
+    assert isinstance(curve, list)
+    assert len(curve) == 1


### PR DESCRIPTION
## Summary
- add parametrized coverage of all training modes
- handle block-orthogonal case in `train_single`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d303d434832890b4b5a691d65ed3