### PR TITLE
Clarify entrypoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ pip install -e .[dev]
 ```
 
 ## Getting Started
-Experiments are launched via `python experiments/ternary_dfa_experiment.py`. A wrapper script at the repository root (`ternary_dfa_experiment.py`) provides the same interface for backward compatibility. The general pattern is
+The recommended entry point is `python experiments/ternary_dfa_experiment.py`.
+A wrapper script at the repository root (`ternary_dfa_experiment.py`) offers the
+same interface for backward compatibility. The general pattern is
 
 ```bash
 python experiments/ternary_dfa_experiment.py --depths <d1 d2 ...> --freqs <f1 f2 ...> \


### PR DESCRIPTION
## Summary
- clarify that `python experiments/ternary_dfa_experiment.py` is the main entry point
- note that the root `ternary_dfa_experiment.py` remains as a compatibility wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875902c03f48328bd72546775522c58