### PR TITLE
Add numpy micro-benchmark and CI reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,22 @@ jobs:
         run: make lint
       - name: Run tests
         run: make test
+      - name: Micro-benchmark (offline)
+        run: |
+          python scripts/bench_micro.py --seeds 123 124 125 --steps 64 --out .artifacts/bench
+      - name: Attach benchmark to Step Summary
+        run: |
+          echo "## FeedFlipNets Micro-Benchmark" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          cat .artifacts/bench/bench_micro.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-micro
+          path: |
+            .artifacts/bench/bench_micro.md
+            .artifacts/bench/bench_micro.csv
+            .artifacts/bench/results.jsonl
       - name: Smoke test
         run: make smoke
       - name: Archive smoke artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap lint test smoke perf bundle release-rc
+.PHONY: bootstrap lint test smoke perf bundle release-rc bench
 
 VENV ?= .venv
 PYTHON ?= python3
@@ -32,4 +32,7 @@ bundle:
 	PYTHONPATH=. FEEDFLIP_DATA_OFFLINE=1 $(VENV)/bin/python scripts/build_paper_bundle.py --run-dir "$$latest" --out paper_bundle --include-plots
 
 release-rc:
-	@echo "FeedFlipNets v1.0.0-rc1 candidate ready. Run make lint test perf bundle before tagging."
+        @echo "FeedFlipNets v1.0.0-rc1 candidate ready. Run make lint test perf bundle before tagging."
+
+bench:
+        . .venv/bin/activate && python scripts/bench_micro.py --out .artifacts/bench

--- a/feedflipnets/core/np_mlp.py
+++ b/feedflipnets/core/np_mlp.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import numpy as np
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+Array = np.ndarray
+
+
+def relu(x: Array) -> Array:
+    return np.maximum(0.0, x)
+
+
+def softmax(z: Array) -> Array:
+    z = z - z.max(axis=1, keepdims=True)
+    e = np.exp(z, dtype=np.float64)
+    return (e / e.sum(axis=1, keepdims=True)).astype(np.float64)
+
+
+def one_hot(y: Array, num_classes: int) -> Array:
+    out = np.zeros((y.shape[0], num_classes), dtype=np.float64)
+    out[np.arange(y.shape[0]), y] = 1.0
+    return out
+
+
+def accuracy(y_true: Array, y_pred_logits: Array) -> float:
+    return float((y_true == y_pred_logits.argmax(axis=1)).mean())
+
+
+@dataclass
+class MLP:
+    d: int = 32
+    h: int = 32
+    c: int = 2
+    seed: int = 123
+
+    def __post_init__(self):
+        rng = np.random.default_rng(self.seed)
+        self.W1 = rng.normal(0, 0.1, size=(self.d, self.h))
+        self.b1 = np.zeros(self.h)
+        self.W2 = rng.normal(0, 0.1, size=(self.h, self.c))
+        self.b2 = np.zeros(self.c)
+
+    def forward(self, X: Array) -> Tuple[Array, Array, Array]:
+        a1 = X @ self.W1 + self.b1
+        h = relu(a1)
+        z = h @ self.W2 + self.b2
+        p = softmax(z)
+        return a1, h, p
+
+    def params(self) -> Dict[str, Array]:
+        return {"W1": self.W1, "b1": self.b1, "W2": self.W2, "b2": self.b2}
+
+    def apply(self, grads: Dict[str, Array], lr: float):
+        self.W1 -= lr * grads["W1"]
+        self.b1 -= lr * grads["b1"]
+        self.W2 -= lr * grads["W2"]
+        self.b2 -= lr * grads["b2"]
+
+
+def ce_loss(p: Array, y_oh: Array) -> float:
+    eps = 1e-12
+    return float(-(y_oh * np.log(p + eps)).sum(axis=1).mean())
+
+
+def _backprop_grads(
+    X: Array,
+    a1: Array,
+    h: Array,
+    p: Array,
+    y_oh: Array,
+    params: Dict[str, Array],
+) -> Dict[str, Array]:
+    n = X.shape[0]
+    dL_dz = (p - y_oh) / n
+    dW2 = h.T @ dL_dz
+    db2 = dL_dz.sum(axis=0)
+    dL_dh = dL_dz @ params["W2"].T
+    dL_da1 = dL_dh * (a1 > 0)
+    dW1 = X.T @ dL_da1
+    db1 = dL_da1.sum(axis=0)
+    return {"W1": dW1, "b1": db1, "W2": dW2, "b2": db2}
+
+
+class BackpropStrategy:
+    def grads(self, X, y, model: MLP):
+        y_oh = one_hot(y, model.c)
+        a1, h, p = model.forward(X)
+        return _backprop_grads(X, a1, h, p, y_oh, model.params())
+
+
+class DFAStrategy:
+    def __init__(self, hidden: int, classes: int, seed: int = 0):
+        rng = np.random.default_rng(seed)
+        self.B = rng.normal(0, 1.0, size=(classes, hidden))
+
+    def grads(self, X, y, model: MLP):
+        y_oh = one_hot(y, model.c)
+        a1, h, p = model.forward(X)
+        n = X.shape[0]
+        dL_dz = (p - y_oh) / n
+        dW2 = h.T @ dL_dz
+        db2 = dL_dz.sum(axis=0)
+        dL_dh = dL_dz @ self.B
+        dL_da1 = dL_dh * (a1 > 0)
+        dW1 = X.T @ dL_da1
+        db1 = dL_da1.sum(axis=0)
+        return {"W1": dW1, "b1": db1, "W2": dW2, "b2": db2}
+
+
+def _ternary(g: Array, tau: float) -> Array:
+    s = np.sign(g)
+    m = (np.abs(g) >= tau).astype(g.dtype)
+    return s * m
+
+
+class FlipTernaryStrategy:
+    def __init__(self, hidden: int, classes: int, tau_frac: float = 0.33):
+        self.tau_frac = tau_frac
+
+    def grads(self, X, y, model: MLP):
+        y_oh = one_hot(y, model.c)
+        a1, h, p = model.forward(X)
+        grads = _backprop_grads(X, a1, h, p, y_oh, model.params())
+        q = {}
+        for k, g in grads.items():
+            tau = np.percentile(np.abs(g), self.tau_frac * 100.0)
+            q[k] = _ternary(g, tau=tau)
+        return q
+
+
+def make_dataset(n: int = 512, d: int = 32, seed: int = 123) -> Tuple[Array, Array]:
+    rng = np.random.default_rng(seed)
+    m0 = rng.normal(0.0, 1.0, size=d)
+    m1 = rng.normal(0.5, 1.0, size=d)
+    X0 = rng.normal(m0, 1.0, size=(n // 2, d))
+    X1 = rng.normal(m1, 1.0, size=(n - n // 2, d))
+    X = np.vstack([X0, X1]).astype(np.float64)
+    y = np.concatenate(
+        [
+            np.zeros(X0.shape[0], dtype=np.int64),
+            np.ones(X1.shape[0], dtype=np.int64),
+        ]
+    )
+    idx = rng.permutation(n)
+    return X[idx], y[idx]
+
+
+def train_one(
+    strategy_name: str,
+    seed: int,
+    steps: int = 64,
+    lr: float = 0.05,
+    batch: int = 64,
+) -> Dict[str, float]:
+    d, h, c = 32, 32, 2
+    X, y = make_dataset(n=512, d=d, seed=seed)
+    model = MLP(d=d, h=h, c=c, seed=seed + 1000)
+    if strategy_name == "bp":
+        strat = BackpropStrategy()
+    elif strategy_name == "dfa":
+        strat = DFAStrategy(hidden=h, classes=c, seed=seed + 2000)
+    elif strategy_name == "flip":
+        strat = FlipTernaryStrategy(hidden=h, classes=c, tau_frac=0.33)
+    else:
+        raise ValueError("unknown strategy")
+    rng = np.random.default_rng(seed + 3000)
+    n = X.shape[0]
+    for step in range(steps):
+        idx = rng.choice(n, size=batch, replace=False)
+        grads = strat.grads(X[idx], y[idx], model)
+        model.apply(grads, lr=lr)
+    _, _, p = model.forward(X)
+    return {
+        "final_loss": ce_loss(p, one_hot(y, c)),
+        "final_acc": accuracy(y, p),
+    }

--- a/scripts/bench_micro.py
+++ b/scripts/bench_micro.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from statistics import mean, pstdev
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from feedflipnets.core.np_mlp import train_one
+
+STRATS = ["bp", "dfa", "flip"]
+
+
+def _fmt_mu_sigma(vals):
+    mu = mean(vals)
+    sd = pstdev(vals) if len(vals) > 1 else 0.0
+    return f"{mu:.4f} ± {sd:.4f}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seeds", nargs="+", type=int, default=[123, 124, 125])
+    ap.add_argument("--steps", type=int, default=64)
+    ap.add_argument("--lr", type=float, default=0.05)
+    ap.add_argument("--batch", type=int, default=64)
+    ap.add_argument("--out", type=str, default=".artifacts/bench")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    runs = []
+    for strat in STRATS:
+        for s in args.seeds:
+            r = train_one(strat, seed=s, steps=args.steps, lr=args.lr, batch=args.batch)
+            runs.append({"strategy": strat, "seed": s, **r})
+    (out / "results.jsonl").write_text("\n".join(json.dumps(x) for x in runs), encoding="utf-8")
+
+    agg = {}
+    for strat in STRATS:
+        accs = [r["final_acc"] for r in runs if r["strategy"] == strat]
+        losses = [r["final_loss"] for r in runs if r["strategy"] == strat]
+        agg[strat] = {
+            "n": len(accs),
+            "final_acc_mu": mean(accs),
+            "final_acc_sd": pstdev(accs) if len(accs) > 1 else 0.0,
+            "final_loss_mu": mean(losses),
+            "final_loss_sd": pstdev(losses) if len(losses) > 1 else 0.0,
+        }
+    bp_acc = agg["bp"]["final_acc_mu"]
+    for strat in STRATS:
+        agg[strat]["delta_acc_vs_bp"] = agg[strat]["final_acc_mu"] - bp_acc
+
+    csv_path = out / "bench_micro.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(
+            [
+                "strategy",
+                "seeds",
+                "steps",
+                "final_loss_mu",
+                "final_loss_sd",
+                "final_acc_mu",
+                "final_acc_sd",
+                "delta_acc_vs_bp",
+            ]
+        )
+        for strat in STRATS:
+            a = agg[strat]
+            w.writerow(
+                [
+                    strat,
+                    agg[strat]["n"],
+                    args.steps,
+                    f"{a['final_loss_mu']:.4f}",
+                    f"{a['final_loss_sd']:.4f}",
+                    f"{a['final_acc_mu']:.4f}",
+                    f"{a['final_acc_sd']:.4f}",
+                    f"{a['delta_acc_vs_bp']:.4f}",
+                ]
+            )
+
+    md_path = out / "bench_micro.md"
+    lines = []
+    lines.append("### Micro‑Benchmark: Backprop vs DFA vs Flip‑Ternary (offline)")
+    lines.append("")
+    lines.append(
+        f"- Seeds: `{args.seeds}`; Steps: `{args.steps}`; LR: `{args.lr}`; Batch: `{args.batch}`"
+    )
+    lines.append("")
+    lines.append("| Strategy | Final Loss (μ±σ) | Final Acc (μ±σ) | ΔAcc vs BP | Seeds | Steps |")
+    lines.append("|---|---:|---:|---:|---:|---:|")
+    for strat in STRATS:
+        a = agg[strat]
+        lines.append(
+            "| {} | {} | {} | {:+.4f} | {} | {} |".format(
+                strat.upper(),
+                _fmt_mu_sigma([r["final_loss"] for r in runs if r["strategy"] == strat]),
+                _fmt_mu_sigma([r["final_acc"] for r in runs if r["strategy"] == strat]),
+                a["delta_acc_vs_bp"],
+                a["n"],
+                args.steps,
+            )
+        )
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    print("Wrote:", csv_path, md_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_bench_micro.py
+++ b/tests/integration/test_bench_micro.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+
+
+def test_bench_micro_runs_quickly(tmp_path):
+    out = tmp_path / "bench"
+    out.mkdir(parents=True, exist_ok=True)
+    subprocess.check_call(
+        [
+            sys.executable,
+            "scripts/bench_micro.py",
+            "--seeds",
+            "123",
+            "--steps",
+            "8",
+            "--out",
+            str(out),
+        ]
+    )
+    md = (out / "bench_micro.md").read_text(encoding="utf-8")
+    assert "| BP |" in md and "| DFA |" in md and "| FLIP |" in md


### PR DESCRIPTION
## Summary
- add a deterministic NumPy MLP implementation with backprop, DFA, and flip-ternary training strategies
- create a micro-benchmark script that emits Markdown and CSV reports and expose it via a Makefile target
- run the benchmark in CI, publish the results to the job summary, and upload the artifacts; add an integration test to keep it fast

## Testing
- python scripts/bench_micro.py --seeds 123 124 --steps 8 --out .artifacts/test
- pytest tests/integration/test_bench_micro.py


------
https://chatgpt.com/codex/tasks/task_e_68e6a8d9f5b483289a2e9c565deb1f4d