### PR TITLE
Fix lint issues across datasets and scripts

### DIFF
--- a/datasets/mnist.py
+++ b/datasets/mnist.py
@@ -7,7 +7,7 @@ from typing import Tuple
 
 import numpy as np
 
-from .utils import normalize, download_file
+from .utils import normalize
 
 
 _DEF_PATH = os.path.join("datasets_cache", "mnist.npz")

--- a/experiments/ternary_dfa_experiment.py
+++ b/experiments/ternary_dfa_experiment.py
@@ -21,13 +21,14 @@ Dependencies: numpy, matplotlib; optional: scipy, pandas, pytest.
 """
 
 from __future__ import annotations
+
 import argparse
 import os
 import sys
-from typing import List
 
-# Allow running this script directly without installing the package
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+if __package__ in {None, ""}:
+    # Allow running this script directly without installing the package
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from feedflipnets.train import sweep_and_log
 

--- a/feedflipnets/core/np_mlp.py
+++ b/feedflipnets/core/np_mlp.py
@@ -110,7 +110,8 @@ class FlipTernaryStrategy:
 
 def make_dataset(n: int = 512, d: int = 32, seed: int = 123) -> Tuple[Array, Array]:
     rng = np.random.default_rng(seed)
-    m0 = rng.normal(0.0, 1.0, size=d);  m1 = rng.normal(0.5, 1.0, size=d)
+    m0 = rng.normal(0.0, 1.0, size=d)
+    m1 = rng.normal(0.5, 1.0, size=d)
     X0 = rng.normal(m0, 1.0, size=(n // 2, d))
     X1 = rng.normal(m1, 1.0, size=(n - n // 2, d))
     X  = np.vstack([X0, X1]).astype(np.float64)

--- a/scripts/bench_micro.py
+++ b/scripts/bench_micro.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-import argparse, csv, json
+import argparse
+import csv
+import json
 from pathlib import Path
 from statistics import mean, pstdev
 from feedflipnets.core.np_mlp import train_one
@@ -20,7 +22,8 @@ def main():
     ap.add_argument("--out", type=str, default=".artifacts/bench")
     args = ap.parse_args()
 
-    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
     runs = []
     for strat in STRATS:
         for s in args.seeds:

--- a/tests/integration/test_bench_micro.py
+++ b/tests/integration/test_bench_micro.py
@@ -1,5 +1,5 @@
-import subprocess, sys
-from pathlib import Path
+import subprocess
+import sys
 
 def test_bench_micro_runs_quickly(tmp_path):
     out = tmp_path / "bench"


### PR DESCRIPTION
## Summary
- remove unused imports flagged by Ruff
- split combined statements in scripts and core module to satisfy style rules
- adjust experiment entrypoint path handling while keeping imports at top of file

## Testing
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e7635b910c8328820b9f5a208dff07