### PR TITLE
Fix Ruff and Black lint issues

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -6,6 +6,10 @@ from .tinystories import load_tinystories
 from .utils import normalize, batch_iter, download_file
 
 __all__ = [
-    "load_mnist", "load_ucr", "load_tinystories",
-    "normalize", "batch_iter", "download_file",
+    "load_mnist",
+    "load_ucr",
+    "load_tinystories",
+    "normalize",
+    "batch_iter",
+    "download_file",
 ]

--- a/datasets/mnist.py
+++ b/datasets/mnist.py
@@ -13,7 +13,9 @@ from .utils import normalize
 _DEF_PATH = os.path.join("datasets_cache", "mnist.npz")
 
 
-def load_mnist(path: str = _DEF_PATH) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def load_mnist(
+    path: str = _DEF_PATH,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Download (if needed) and return MNIST as numpy arrays."""
     if os.path.exists(path):
         with np.load(path) as f:

--- a/datasets/timeseries.py
+++ b/datasets/timeseries.py
@@ -22,7 +22,9 @@ def _extract_dataset(name: str, root: str) -> str:
     return extract_dir
 
 
-def load_ucr(name: str, root: str = "datasets_cache") -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def load_ucr(
+    name: str, root: str = "datasets_cache"
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Load a dataset from the UCR/UEA archive.
 
     Returns (X_train, y_train, X_test, y_test) arrays normalised per time-series.

--- a/datasets/utils.py
+++ b/datasets/utils.py
@@ -24,8 +24,10 @@ def normalize(data: np.ndarray, axis=None) -> np.ndarray:
     return (data - mean) / std
 
 
-def batch_iter(data: np.ndarray, labels: np.ndarray, batch_size: int) -> Iterable[Tuple[np.ndarray, np.ndarray]]:
+def batch_iter(
+    data: np.ndarray, labels: np.ndarray, batch_size: int
+) -> Iterable[Tuple[np.ndarray, np.ndarray]]:
     """Simple batch iterator."""
     n = data.shape[0]
     for i in range(0, n, batch_size):
-        yield data[i:i + batch_size], labels[i:i + batch_size]
+        yield data[i : i + batch_size], labels[i : i + batch_size]

--- a/experiments/ternary_dfa_experiment.py
+++ b/experiments/ternary_dfa_experiment.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402  # imports may appear after code in this script
 """
 Ternary-DFA Experiment Script  (v8.2 – complete logging + plots + extra metrics)
 ================================================================================
@@ -35,16 +36,24 @@ from feedflipnets.train import sweep_and_log
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Run Ternary-DFA experiment")
-    p.add_argument('--methods', nargs='+', default=['Backprop'])
-    p.add_argument('--depths', type=int, nargs='+', required=True)
-    p.add_argument('--freqs', type=int, nargs='+', required=True)
-    p.add_argument('--epochs', type=int, default=500)
-    p.add_argument('--outdir', type=str, default='results')
-    p.add_argument('--seeds', type=int, nargs='+', default=[0])
-    p.add_argument('--dataset', type=str, default=None,
-                   help='Dataset to use (mnist, tinystories or ucr:<name>)')
-    p.add_argument('--max-points', type=int, default=None,
-                   help='Limit dataset to this many points for quick runs')
+    p.add_argument("--methods", nargs="+", default=["Backprop"])
+    p.add_argument("--depths", type=int, nargs="+", required=True)
+    p.add_argument("--freqs", type=int, nargs="+", required=True)
+    p.add_argument("--epochs", type=int, default=500)
+    p.add_argument("--outdir", type=str, default="results")
+    p.add_argument("--seeds", type=int, nargs="+", default=[0])
+    p.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="Dataset to use (mnist, tinystories or ucr:<name>)",
+    )
+    p.add_argument(
+        "--max-points",
+        type=int,
+        default=None,
+        help="Limit dataset to this many points for quick runs",
+    )
     return p.parse_args()
 
 
@@ -63,5 +72,5 @@ def main(args: argparse.Namespace | None = None) -> None:
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/feedflipnets/core/np_mlp.py
+++ b/feedflipnets/core/np_mlp.py
@@ -5,21 +5,26 @@ from typing import Dict, Tuple
 
 Array = np.ndarray
 
+
 def relu(x: Array) -> Array:
     return np.maximum(0.0, x)
+
 
 def softmax(z: Array) -> Array:
     z = z - z.max(axis=1, keepdims=True)
     e = np.exp(z, dtype=np.float64)
     return (e / e.sum(axis=1, keepdims=True)).astype(np.float64)
 
+
 def one_hot(y: Array, num_classes: int) -> Array:
     out = np.zeros((y.shape[0], num_classes), dtype=np.float64)
     out[np.arange(y.shape[0]), y] = 1.0
     return out
 
+
 def accuracy(y_true: Array, y_pred_logits: Array) -> float:
     return float((y_true == y_pred_logits.argmax(axis=1)).mean())
+
 
 @dataclass
 class MLP:
@@ -37,9 +42,9 @@ class MLP:
 
     def forward(self, X: Array) -> Tuple[Array, Array, Array]:
         a1 = X @ self.W1 + self.b1
-        h  = relu(a1)
-        z  = h @ self.W2 + self.b2
-        p  = softmax(z)
+        h = relu(a1)
+        z = h @ self.W2 + self.b2
+        p = softmax(z)
         return a1, h, p
 
     def params(self) -> Dict[str, Array]:
@@ -51,26 +56,32 @@ class MLP:
         self.W2 -= lr * grads["W2"]
         self.b2 -= lr * grads["b2"]
 
+
 def ce_loss(p: Array, y_oh: Array) -> float:
     eps = 1e-12
     return float(-(y_oh * np.log(p + eps)).sum(axis=1).mean())
 
-def _backprop_grads(X: Array, a1: Array, h: Array, p: Array, y_oh: Array, params: Dict[str, Array]) -> Dict[str, Array]:
+
+def _backprop_grads(
+    X: Array, a1: Array, h: Array, p: Array, y_oh: Array, params: Dict[str, Array]
+) -> Dict[str, Array]:
     n = X.shape[0]
     dL_dz = (p - y_oh) / n
-    dW2   = h.T @ dL_dz
-    db2   = dL_dz.sum(axis=0)
+    dW2 = h.T @ dL_dz
+    db2 = dL_dz.sum(axis=0)
     dL_dh = dL_dz @ params["W2"].T
-    dL_da1= dL_dh * (a1 > 0)
-    dW1   = X.T @ dL_da1
-    db1   = dL_da1.sum(axis=0)
+    dL_da1 = dL_dh * (a1 > 0)
+    dW1 = X.T @ dL_da1
+    db1 = dL_da1.sum(axis=0)
     return {"W1": dW1, "b1": db1, "W2": dW2, "b2": db2}
+
 
 class BackpropStrategy:
     def grads(self, X, y, model: MLP):
         y_oh = one_hot(y, model.c)
         a1, h, p = model.forward(X)
         return _backprop_grads(X, a1, h, p, y_oh, model.params())
+
 
 class DFAStrategy:
     def __init__(self, hidden: int, classes: int, seed: int = 0):
@@ -82,22 +93,25 @@ class DFAStrategy:
         a1, h, p = model.forward(X)
         n = X.shape[0]
         dL_dz = (p - y_oh) / n
-        dW2   = h.T @ dL_dz
-        db2   = dL_dz.sum(axis=0)
+        dW2 = h.T @ dL_dz
+        db2 = dL_dz.sum(axis=0)
         dL_dh = dL_dz @ self.B
-        dL_da1= dL_dh * (a1 > 0)
-        dW1   = X.T @ dL_da1
-        db1   = dL_da1.sum(axis=0)
+        dL_da1 = dL_dh * (a1 > 0)
+        dW1 = X.T @ dL_da1
+        db1 = dL_da1.sum(axis=0)
         return {"W1": dW1, "b1": db1, "W2": dW2, "b2": db2}
+
 
 def _ternary(g: Array, tau: float) -> Array:
     s = np.sign(g)
     m = (np.abs(g) >= tau).astype(g.dtype)
     return s * m
 
+
 class FlipTernaryStrategy:
     def __init__(self, hidden: int, classes: int, tau_frac: float = 0.33):
         self.tau_frac = tau_frac
+
     def grads(self, X, y, model: MLP):
         y_oh = one_hot(y, model.c)
         a1, h, p = model.forward(X)
@@ -108,19 +122,24 @@ class FlipTernaryStrategy:
             q[k] = _ternary(g, tau=tau)
         return q
 
+
 def make_dataset(n: int = 512, d: int = 32, seed: int = 123) -> Tuple[Array, Array]:
     rng = np.random.default_rng(seed)
     m0 = rng.normal(0.0, 1.0, size=d)
     m1 = rng.normal(0.5, 1.0, size=d)
     X0 = rng.normal(m0, 1.0, size=(n // 2, d))
     X1 = rng.normal(m1, 1.0, size=(n - n // 2, d))
-    X  = np.vstack([X0, X1]).astype(np.float64)
-    y  = np.concatenate([np.zeros(X0.shape[0], dtype=np.int64),
-                         np.ones(X1.shape[0],  dtype=np.int64)])
+    X = np.vstack([X0, X1]).astype(np.float64)
+    y = np.concatenate(
+        [np.zeros(X0.shape[0], dtype=np.int64), np.ones(X1.shape[0], dtype=np.int64)]
+    )
     idx = rng.permutation(n)
     return X[idx], y[idx]
 
-def train_one(strategy_name: str, seed: int, steps: int = 64, lr: float = 0.05, batch: int = 64) -> Dict[str, float]:
+
+def train_one(
+    strategy_name: str, seed: int, steps: int = 64, lr: float = 0.05, batch: int = 64
+) -> Dict[str, float]:
     d, h, c = 32, 32, 2
     X, y = make_dataset(n=512, d=d, seed=seed)
     model = MLP(d=d, h=h, c=c, seed=seed + 1000)

--- a/tests/integration/test_bench_micro.py
+++ b/tests/integration/test_bench_micro.py
@@ -1,9 +1,21 @@
 import subprocess
 import sys
 
+
 def test_bench_micro_runs_quickly(tmp_path):
     out = tmp_path / "bench"
     out.mkdir(parents=True, exist_ok=True)
-    subprocess.check_call([sys.executable, "scripts/bench_micro.py", "--seeds","123","--steps","8","--out", str(out)])
+    subprocess.check_call(
+        [
+            sys.executable,
+            "scripts/bench_micro.py",
+            "--seeds",
+            "123",
+            "--steps",
+            "8",
+            "--out",
+            str(out),
+        ]
+    )
     md = (out / "bench_micro.md").read_text(encoding="utf-8")
     assert "| BP |" in md and "| DFA |" in md and "| FLIP |" in md


### PR DESCRIPTION
## Summary
- split combined statements and reflow formatting in `bench_micro` tooling and tests
- clean up dataset utilities and numpy MLP module to satisfy Ruff lint
- guard the ternary DFA experiment script with a file-level E402 suppression comment

## Testing
- pytest -q -k "bench_micro or offline or not network" *(fails: ModuleNotFoundError for package imports when running outside editable install)*

------
https://chatgpt.com/codex/tasks/task_e_68e8aebf6e548328bad3c1227f30956f