### PR TITLE
Ensure CI workflow adds workspace to PYTHONPATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       PYTHONUNBUFFERED: "1"
       FEEDFLIP_OFFLINE: "1"
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add the repository workspace to PYTHONPATH in the CI workflow so pytest can import the project modules

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e9e930bdd8832897dc0e854b3457ae