### PR TITLE
Restore MNIST offline fixture checksum and fix packaging

### DIFF
--- a/feedflipnets/data/loaders/mnist.py
+++ b/feedflipnets/data/loaders/mnist.py
@@ -12,7 +12,7 @@ from ..cache import fetch
 from ..registry import DatasetSpec, register_dataset
 
 _URL = "https://storage.googleapis.com/tf-keras-datasets/mnist.npz"
-_CHECKSUM = "fe63ad0f25b57d1097017e6636e2e3b5676d8d2d1b59f2ce20c06e5581eabea2"
+_CHECKSUM = "c4c5d4fa681872f17d7e4ef9910ea1a5dbef4ada1e77e7a6ff11fb09f827c229"
 
 
 def _build_offline_fixture(path: Path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ dev = ["pytest"]
 
 [tool.setuptools]
 py-modules = ["ternary_dfa_experiment"]
+
+[tool.setuptools.packages.find]
+include = ["feedflipnets", "feedflipnets.*", "cli", "cli.*"]


### PR DESCRIPTION
## Summary
- revert the MNIST offline fixture checksum to match the deterministic fixture produced by the offline builder
- ensure setuptools package discovery includes the feedflipnets and cli packages so editable installs succeed across Python versions

## Testing
- PYTHONPATH=. pytest tests/unit/test_dataset_loaders.py::test_mnist_offline

------
https://chatgpt.com/codex/tasks/task_e_68e9f7b576a08328b5e3c991ebe4fe72