### PR TITLE
Remove Python 3.10 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     env:
       PYTHONUNBUFFERED: "1"
       FEEDFLIP_OFFLINE: "1"


### PR DESCRIPTION
## Summary
- update the CI workflow to only run on Python 3.11

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9ffb6565883288a1282363751d81c