### PR TITLE
Raise lint line length to 100

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+# These align flake8 with Black’s formatting rules, should you adopt Black
+extend-ignore = E203, W503

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,7 @@ dev = [
 
 [tool.setuptools]
 py-modules = ["ternary_dfa_experiment"]
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]


### PR DESCRIPTION
## Summary
- add a repo-root flake8 configuration raising the max line length to 100 and aligning ignores
- configure Black to use a matching 100 character line length targeting Python 3.10

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea5d68d5a083289f43df2c08becff8