### PR TITLE
Fix flake8 line length errors in legacy training module

### DIFF
--- a/feedflipnets/train.py
+++ b/feedflipnets/train.py
@@ -57,16 +57,55 @@ def _infer_dims(data_cfg: Dict[str, object]) -> Tuple[int, int]:
     return batch.inputs.shape[1], batch.targets.shape[1]
 
 
+_DEFAULT_METHOD = {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"}
+
+
 _METHOD_MAP = {
-    "Backprop": {"strategy": "backprop", "flip": "off", "flip_schedule": "off"},
-    "Vanilla DFA": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
-    "Structured DFA": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
-    "Ternary static Δ": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
-    "Ternary + adaptive + ortho B": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
-    "Ternary + adaptive + ortho B + cal": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
-    "+Shadow": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
-    "+Momentum": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
-    "Ternary DFA on Transformer/LLM": {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"},
+    "Backprop": {
+        "strategy": "backprop",
+        "flip": "off",
+        "flip_schedule": "off",
+    },
+    "Vanilla DFA": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
+    "Structured DFA": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
+    "Ternary static Δ": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
+    "Ternary + adaptive + ortho B": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
+    "Ternary + adaptive + ortho B + cal": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
+    "+Shadow": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
+    "+Momentum": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
+    "Ternary DFA on Transformer/LLM": {
+        "strategy": "dfa",
+        "flip": "ternary",
+        "flip_schedule": "per_step",
+    },
 }
 
 
@@ -89,7 +128,7 @@ def train_single(
     data_cfg = _dataset_options(dataset, freq, max_points, seed)
     d_in, d_out = _infer_dims(data_cfg)
     hidden = [16] * max(depth, 1)
-    mapping = _METHOD_MAP.get(method, {"strategy": "dfa", "flip": "ternary", "flip_schedule": "per_step"})
+    mapping = _METHOD_MAP.get(method, _DEFAULT_METHOD)
     strategy = mapping.get("strategy", "dfa")
 
     config = {
@@ -124,7 +163,10 @@ def train_single(
             record = json.loads(line)
             losses.append(float(record.get("loss", 0.0)))
     auc = float(_trapezoid(losses)) if losses else 0.0
-    t01 = next((idx for idx, loss in enumerate(losses) if loss < 0.01), epochs + 1)
+    t01 = next(
+        (idx for idx, loss in enumerate(losses) if loss < 0.01),
+        epochs + 1,
+    )
     return losses, auc, t01
 
 

--- a/feedflipnets/training/trainer.py
+++ b/feedflipnets/training/trainer.py
@@ -202,9 +202,7 @@ class Trainer:
             resolved_schedule = (flip_schedule or "per_step").lower()
 
         if resolved_schedule not in {"off", "per_step", "per_epoch"}:
-            raise ValueError(
-                "flip_schedule must be one of {'off','per_step','per_epoch'}"
-            )
+            raise ValueError("flip_schedule must be one of {'off','per_step','per_epoch'}")
 
         flip_enabled = flip != "off"
 

--- a/tests/test_training_loops.py
+++ b/tests/test_training_loops.py
@@ -138,7 +138,11 @@ def test_binary_metrics_and_checkpoints(tmp_path, flip_schedule: str) -> None:
 
     ckpt_dir = tmp_path / flip_schedule
     ckpt_dir.mkdir()
-    run_kwargs = {"flip": "off"} if flip_schedule == "off" else {"flip": "ternary", "flip_schedule": flip_schedule}
+    run_kwargs = (
+        {"flip": "off"}
+        if flip_schedule == "off"
+        else {"flip": "ternary", "flip_schedule": flip_schedule}
+    )
     trainer.run(
         loader,
         epochs=25,


### PR DESCRIPTION
## Summary
- factor out a default method mapping and reformat legacy method table in `feedflipnets.train`
- wrap long expressions in `feedflipnets.train` and training loop tests to satisfy flake8 line-length limits

## Testing
- flake8 cli feedflipnets scripts tests

------
https://chatgpt.com/codex/tasks/task_e_68eaa5f404e48328b14b1255130429fa